### PR TITLE
Reworked check_to_continue method to be easier to maintain

### DIFF
--- a/tests/plugins/test_http_links_in_tags.py
+++ b/tests/plugins/test_http_links_in_tags.py
@@ -97,3 +97,54 @@ class CheckHttpLinksInTagsTestCase(PluginTestCase):
             'value:"https://nvd.nist.gov/vuln/detail/CVE-1234");',
             results[0].message,
         )
+
+    def test_http_link_in_tags_ok(self):
+        testcases = [
+            "01. The payloads try to open a connection to www.google.com",
+            "02. The script attempts to connect to www.google.com",
+            "03. to retrieve a web page from www.google.com",
+            "04. Subject: commonName=www.paypal.com",
+            "05. Terms of use at https://www.verisign.com/rpa",
+            "06. example.com",
+            "07. example.org",
+            "08. www.exam",
+            "09. sampling the resolution of a name (www.google.com)",
+            "10. once with 'www.' and once without",
+            "11. wget http://www.javaop.com/~ron/tmp/nc",
+            "12. Ncat: Version 5.30BETA1 (http://nmap.org/ncat)",
+            "13. as www.windowsupdate.com. (BZ#506016)",
+            "14. located at http://sambarserver/session/pagecount.",
+            "15. http://rest.modx.com",
+            "16. ftp:// ",
+            "17. ftp://'",
+            "18. ftp://)",
+            "19. ftp.c",
+            "20. ftp.exe",
+            "21. using special ftp://",
+            "22. running ftp.",
+            "23. ftp. The vulnerability",
+            "24. 'http://' protocol",
+            "25. handle <a href='http://...'> properly",
+            "26. Switch to git+https://",
+            "27. wget https://compromised-domain.com/important-file",
+            "28. the https:// scheme",
+            "29. https://www.phishingtarget.com@evil.com",
+            "30. 'http://'",
+            "31. 'https://'",
+        ]
+
+        for testcase in testcases:
+            self.assertTrue(CheckHttpLinksInTags.check_to_continue(testcase))
+
+    def test_http_link_in_tags_not_ok(self):
+        testcases = [
+            "The payloads try to open a connection to www.bing.com",
+            "examplephishing.org",
+            "located at http://sambdadancinglessions/session/pagecount.",
+            "fdp:// ",
+            "Switch to svn+https://",
+            "greenbone.net",
+        ]
+
+        for testcase in testcases:
+            self.assertFalse(CheckHttpLinksInTags.check_to_continue(testcase))

--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -115,94 +115,41 @@ class CheckHttpLinksInTags(FilePlugin):
 
     @staticmethod
     def check_to_continue(http_link_match_group: AnyStr) -> bool:
-        if (
-            "The payloads try to open a connection to www.google.com"
-            in http_link_match_group
-        ):
-            return True
-        if (
-            "The script attempts to connect to www.google.com"
-            in http_link_match_group
-        ):
-            return True
-        if (
-            "to retrieve a web page from www.google.com"
-            in http_link_match_group
-        ):
-            return True
-        if "Subject: commonName=www.paypal.com" in http_link_match_group:
-            return True
-        if (
-            "Terms of use at https://www.verisign.com/rpa"
-            in http_link_match_group
-        ):
-            return True
-        if (
-            "example.com" in http_link_match_group
-            or "example.org" in http_link_match_group
-        ):
-            return True
-        if "www.exam" in http_link_match_group:
-            return True
-        if (
-            "sampling the resolution of a name (www.google.com)"
-            in http_link_match_group
-        ):
-            return True
-        if "once with 'www.' and once without" in http_link_match_group:
-            return True
-        if "wget http://www.javaop.com/~ron/tmp/nc" in http_link_match_group:
-            return True
-        if (
-            "Ncat: Version 5.30BETA1 (http://nmap.org/ncat)"
-            in http_link_match_group
-        ):
-            return True
-        if "as www.windowsupdate.com. (BZ#506016)" in http_link_match_group:
-            return True
-        if (
-            "located at http://sambarserver/session/pagecount."
-            in http_link_match_group
-        ):
-            return True
-        if "http://rest.modx.com" in http_link_match_group:
-            return True
-        if (
-            "ftp:// " in http_link_match_group
-            or "ftp://'" in http_link_match_group
-            or "ftp://)" in http_link_match_group
-            or "ftp.c" in http_link_match_group
-            or "ftp.exe" in http_link_match_group
-        ):
-            return True
-        if (
-            "using special ftp://" in http_link_match_group
-            or "running ftp." in http_link_match_group
-            or "ftp. The vulnerability" in http_link_match_group
-        ):
-            return True
-        if (
-            "'http://' protocol" in http_link_match_group
-            or "handle <a href='http://...'> properly" in http_link_match_group
-        ):
-            return True
-        if "Switch to git+https://" in http_link_match_group:
-            return True
-        if (
-            "wget https://compromised-domain.com/important-file"
-            in http_link_match_group
-        ):
-            return True
-        if "the https:// scheme" in http_link_match_group:
-            return True
-        if "https://www.phishingtarget.com@evil.com" in http_link_match_group:
-            return True
-        # e.g.:
-        # Since gedit supports opening files via 'http://' URLs
-        if (
-            "'http://'" in http_link_match_group
-            or "'https://'" in http_link_match_group
-        ):
-            return True
+        exclusions = [
+            "The payloads try to open a connection to www.google.com",
+            "The script attempts to connect to www.google.com",
+            "to retrieve a web page from www.google.com",
+            "Terms of use at https://www.verisign.com/rpa",
+            "Subject: commonName=www.paypal.com",
+            "example.com",
+            "example.org",
+            "www.exam",
+            "sampling the resolution of a name (www.google.com)",
+            "once with 'www.' and once without",
+            "wget http://www.javaop.com/~ron/tmp/nc",
+            "Ncat: Version 5.30BETA1 (http://nmap.org/ncat)",
+            "as www.windowsupdate.com. (BZ#506016)",
+            "located at http://sambarserver/session/pagecount.",
+            "http://rest.modx.com",
+            "ftp:// ",
+            "ftp://'",
+            "ftp://)",
+            "ftp.c",
+            "ftp.exe",
+            "using special ftp://",
+            "running ftp.",
+            "ftp. The vulnerability",
+            "'http://' protocol",
+            "handle <a href='http://...'> properly",
+            "Switch to git+https://",
+            "wget https://compromised-domain.com/important-file",
+            "the https:// scheme",
+            "https://www.phishingtarget.com@evil.com"
+            # e.g.:
+            # Since gedit supports opening files via 'http://' URLs
+            "'http://'" "'https://'",
+        ]
 
-        return False
+        return any(
+            exclusion in http_link_match_group for exclusion in exclusions
+        )

--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -144,10 +144,11 @@ class CheckHttpLinksInTags(FilePlugin):
             "Switch to git+https://",
             "wget https://compromised-domain.com/important-file",
             "the https:// scheme",
-            "https://www.phishingtarget.com@evil.com"
+            "https://www.phishingtarget.com@evil.com",
             # e.g.:
             # Since gedit supports opening files via 'http://' URLs
-            "'http://'" "'https://'",
+            "'http://'",
+            "'https://'",
         ]
 
         return any(

--- a/troubadix/plugins/http_links_in_tags.py
+++ b/troubadix/plugins/http_links_in_tags.py
@@ -115,6 +115,8 @@ class CheckHttpLinksInTags(FilePlugin):
 
     @staticmethod
     def check_to_continue(http_link_match_group: AnyStr) -> bool:
+        # When adding new entries to this list, please also add a testcase to
+        # tests/plugins/test_http_links_in_tags.py -> test_http_link_in_tags_ok
         exclusions = [
             "The payloads try to open a connection to www.google.com",
             "The script attempts to connect to www.google.com",


### PR DESCRIPTION
**What**:

Reworked check_to_continue method to be easier to maintain by creating a simple list of text phrases to exclude and then looping over them

**Why**:

It is way easier to maintain and add new entries

**How**:

Passes the existing unittests

**Checklist**:

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
